### PR TITLE
keep line-height = 1.5

### DIFF
--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -44,7 +44,6 @@
     .post-excerpt {
         &, * {
             font-size: $small-font-size;
-            line-height: $small-font-size;
             padding-top: 0;
             padding-bottom: 0;
 	        color: #333;


### PR DESCRIPTION
如果 font-size 和 line-height 的尺寸都是 $small-font-size 的话，就会出现文字重叠的问题，所以保持最初的1.5倍行高已经是比较好的显示了。